### PR TITLE
Fix stat service endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "moment-timezone": "^0.5.28",
         "nem-sdk": "^1.6.8",
         "symbol-sdk": "^1.0.3",
+        "symbol-statistics-service-typescript-fetch-client": "^1.1.3-alpha-202111301530",
         "url-parse": "^1.5.2",
         "utf8": "^3.0.0",
         "vue": "^2.6.11",
@@ -25285,6 +25286,11 @@
         "node": ">=8.3.0"
       }
     },
+    "node_modules/symbol-statistics-service-typescript-fetch-client": {
+      "version": "1.1.3-alpha-202111301530",
+      "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.3-alpha-202111301530.tgz",
+      "integrity": "sha512-t9niML12ZB+VRG2XqYDr1yZXkyQVH8RVYLXfO8x6QmG1UpK9dtunTmysnCGBXEiFDsytKzMaGDIbsjdOuDdbmw=="
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -49633,6 +49639,11 @@
           "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
         }
       }
+    },
+    "symbol-statistics-service-typescript-fetch-client": {
+      "version": "1.1.3-alpha-202111301530",
+      "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.3-alpha-202111301530.tgz",
+      "integrity": "sha512-t9niML12ZB+VRG2XqYDr1yZXkyQVH8RVYLXfO8x6QmG1UpK9dtunTmysnCGBXEiFDsytKzMaGDIbsjdOuDdbmw=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "moment-timezone": "^0.5.28",
         "nem-sdk": "^1.6.8",
         "symbol-sdk": "^1.0.3",
-        "symbol-statistics-service-typescript-fetch-client": "^1.1.3-alpha-202111301530",
+        "symbol-statistics-service-typescript-fetch-client": "^1.1.3",
         "url-parse": "^1.5.2",
         "utf8": "^3.0.0",
         "vue": "^2.6.11",
@@ -25287,9 +25287,9 @@
       }
     },
     "node_modules/symbol-statistics-service-typescript-fetch-client": {
-      "version": "1.1.3-alpha-202111301530",
-      "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.3-alpha-202111301530.tgz",
-      "integrity": "sha512-t9niML12ZB+VRG2XqYDr1yZXkyQVH8RVYLXfO8x6QmG1UpK9dtunTmysnCGBXEiFDsytKzMaGDIbsjdOuDdbmw=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.3.tgz",
+      "integrity": "sha512-RRGRp8gVkV2muUgRJCgEkoSt1ietWmvqyYppz2wohtNyAAmPDeWdQDDt3fp3mw6ZmviHr9ZpehaG2J0gxHlMWg=="
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -49641,9 +49641,9 @@
       }
     },
     "symbol-statistics-service-typescript-fetch-client": {
-      "version": "1.1.3-alpha-202111301530",
-      "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.3-alpha-202111301530.tgz",
-      "integrity": "sha512-t9niML12ZB+VRG2XqYDr1yZXkyQVH8RVYLXfO8x6QmG1UpK9dtunTmysnCGBXEiFDsytKzMaGDIbsjdOuDdbmw=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.3.tgz",
+      "integrity": "sha512-RRGRp8gVkV2muUgRJCgEkoSt1ietWmvqyYppz2wohtNyAAmPDeWdQDDt3fp3mw6ZmviHr9ZpehaG2J0gxHlMWg=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "moment-timezone": "^0.5.28",
     "nem-sdk": "^1.6.8",
     "symbol-sdk": "^1.0.3",
-    "symbol-statistics-service-typescript-fetch-client": "^1.1.3-alpha-202111301530",
+    "symbol-statistics-service-typescript-fetch-client": "^1.1.3",
     "url-parse": "^1.5.2",
     "utf8": "^3.0.0",
     "vue": "^2.6.11",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "moment-timezone": "^0.5.28",
     "nem-sdk": "^1.6.8",
     "symbol-sdk": "^1.0.3",
+    "symbol-statistics-service-typescript-fetch-client": "^1.1.3-alpha-202111301530",
     "url-parse": "^1.5.2",
     "utf8": "^3.0.0",
     "vue": "^2.6.11",

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -182,7 +182,7 @@ class NodeService {
     			apiNodeStatus: nodeStatus?.apiNode === 'up' || Constants.Message.UNAVAILABLE,
     			isHttpsEnabled,
     			restVersion,
-    			lastStatusCheck: moment(moment.utc(lastStatusCheck).format(), 'YYYY-MM-DD HH:mm:ss')
+    			lastStatusCheck: moment.utc(lastStatusCheck).format('YYYY-MM-DD HH:mm:ss')
     		};
 
     		if (finalization && chainHeight) {
@@ -193,7 +193,7 @@ class NodeService {
     				finalizationEpoch: finalization?.epoch,
     				finalizationPoint: finalization?.point,
     				finalizedHash: finalization?.hash,
-    				lastStatusCheck: moment(moment.utc(lastStatusCheck).format(), 'YYYY-MM-DD HH:mm:ss')
+    				lastStatusCheck: moment.utc(lastStatusCheck).format('YYYY-MM-DD HH:mm:ss')
     			};
     		}
     		else

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -236,8 +236,8 @@ class NodeService {
 	static getNodeListCSV = async (filter) => {
 		const nodes = await this.getNodePeerList(filter);
 
-		const formattedData = nodes.data.map(node => ({
-			no: node.index,
+		const formattedData = nodes.data.map((node, index) => ({
+			no: index + 1,
 			host: node.host,
 			country: node.country,
 			friendlyName: node.friendlyName.replace(/,/g, '_'), // prevent friendly name break in CSV

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -19,10 +19,8 @@
 import http from './http';
 import Constants from '../config/constants';
 import * as symbol from 'symbol-sdk';
-import Axios from 'axios';
 import moment from 'moment';
 import helper from '../helper';
-import globalConfig from '../config/globalConfig';
 
 class NodeService {
     /**
@@ -61,15 +59,10 @@ class NodeService {
     	let nodePeers = [];
 
     	try {
-    		if (globalConfig.endpoints.statisticsService && globalConfig.endpoints.statisticsService.length)
-    			nodePeers = (await Axios.get(globalConfig.endpoints.statisticsService + '/nodes')).data;
-    		else
-    			throw Error('Statistics service endpoint is not provided');
+    		nodePeers = await http.statisticServiceRestClient().getNodes();
     	}
     	catch (e) {
-    		nodePeers = await http.createRepositoryFactory.createNodeRepository()
-    			.getNodePeers()
-    			.toPromise();
+    		console.error('Statistics service getNodes error: ', e);
     	}
 
     	const formattedNodePeers = nodePeers.map(nodeInfo => this.formatNodeInfo(nodeInfo)).sort((a, b) => a.friendlyName.localeCompare(b.friendlyName));
@@ -168,15 +161,10 @@ class NodeService {
     	let node = {};
 
     	try {
-    		if (globalConfig.endpoints.statisticsService && globalConfig.endpoints.statisticsService.length)
-    			node = (await Axios.get(globalConfig.endpoints.statisticsService + '/nodes/' + publicKey)).data;
-    		else
-    			throw Error('Statistics service endpoint is not provided');
+    		node = await http.statisticServiceRestClient().getNode(publicKey);
     	}
     	catch (e) {
-    		const nodes = (await Axios.get(http.nodeUrl + '/node/peers')).data;
-
-    		node = nodes.find(n => n.publicKey === publicKey);
+    		throw Error('Statistics service getNode error: ', e);
     	}
     	const formattedNode = this.formatNodeInfo(node);
 
@@ -216,61 +204,18 @@ class NodeService {
     	return formattedNode;
     }
 
-    static getApiNodeStatus = async (nodeUrl) => {
-    	const status = {
-    		connectionStatus: false,
-    		databaseStatus: Constants.Message.UNAVAILABLE,
-    		apiNodeStatus: Constants.Message.UNAVAILABLE,
-    		lastStatusCheck: moment().format('YYYY-MM-DD HH:mm:ss')
-    	};
-
-    	try {
-    		const nodeStatus = (await Axios.get(nodeUrl + '/node/health', { timeout: 3000 })).data.status;
-
-    		status.connectionStatus = true;
-    		status.apiNodeStatus = nodeStatus.apiNode === 'up';
-    		status.databaseStatus = nodeStatus.db === 'up';
-    		status.lastStatusCheck = moment().format('YYYY-MM-DD HH:mm:ss');
-    	}
-    	catch (e) {
-    		console.error('Failed to get node status', e);
-    	};
-
-    	return status;
-    }
-
-    static getNodeChainInfo = async (nodeUrl) => {
-    	let chainInfo = {};
-
-    	try {
-    		chainInfo = {};
-    		const nodeChainInfo = (await Axios.get(nodeUrl + '/chain/info', { timeout: 3000 })).data;
-
-    		chainInfo.height = nodeChainInfo.height;
-    		chainInfo.scoreHigh = nodeChainInfo.scoreHigh;
-    		chainInfo.scoreLow = nodeChainInfo.scoreLow;
-    		chainInfo.finalizationEpoch = nodeChainInfo.latestFinalizedBlock.finalizationEpoch;
-    		chainInfo.finalizationPoint = nodeChainInfo.latestFinalizedBlock.finalizationPoint;
-    		chainInfo.finalizedHeight = nodeChainInfo.latestFinalizedBlock.height;
-    		chainInfo.finalizedHash = nodeChainInfo.latestFinalizedBlock.hash;
-    	}
-    	catch (e) {
-    		console.error('Failed to get node chain info', e);
-    	};
-
-    	return chainInfo;
-    }
-
 	static getNodeStats = async () => {
-		if (globalConfig.endpoints.statisticsService && globalConfig.endpoints.statisticsService.length)
-			return (await Axios.get(globalConfig.endpoints.statisticsService + '/nodeStats')).data;
-		else
-			throw Error('Statistics service endpoint is not provided');
+		try {
+			return await http.statisticServiceRestClient().getNodeStats();
+		}
+		catch (e) {
+			throw Error('Statistics service getNodeStats error: ', e);
+		}
 	}
 
 	static getNodeHeightStats = async () => {
-		if (globalConfig.endpoints.statisticsService && globalConfig.endpoints.statisticsService.length) {
-			const data = (await Axios.get(globalConfig.endpoints.statisticsService + '/nodeHeightStats')).data;
+		try {
+			const data = await http.statisticServiceRestClient().getNodeHeightStats();
 
 			return [
 				{
@@ -283,8 +228,9 @@ class NodeService {
 				}
 			];
 		}
-		else
-			throw Error('Statistics service endpoint is not provided');
+		catch (e) {
+			throw Error('Statistics service getNodeHeightStats error: ', e);
+		}
 	}
 
 	static getNodeListCSV = async (filter) => {
@@ -315,26 +261,12 @@ class NodeService {
      * @returns nodes
      */
 	 static getNodeList = async (filter, limit, ssl) => {
-    	let nodes = [];
-
     	try {
-    		if (globalConfig.endpoints.statisticsService && globalConfig.endpoints.statisticsService.length) {
-	 			nodes = (await Axios.get(globalConfig.endpoints.statisticsService + `/nodes`, {
-	 				params: {
-	 					filter,
-						 limit,
-						 ssl
-	 				}
-	 			})).data;
-	 		}
-    		else
-    			throw Error('Statistics service endpoint is not provided');
+	 		return await http.statisticServiceRestClient().getNodes(filter, limit, ssl);
     	}
     	catch (e) {
-    		throw Error('Statistics service endpoint is not provided', e);
-    	}
-
-    	return nodes;
+	 		throw Error('Statistics service getNodeHeightStats error: ', e);
+	 	}
 	 }
 
 	 /**

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -164,13 +164,6 @@ class NodeService {
     	};
     }
 
-	static getNodeStats = async () => {
-		if (globalConfig.endpoints.statisticsService && globalConfig.endpoints.statisticsService.length)
-			return (await Axios.get(globalConfig.endpoints.statisticsService + '/nodestats/')).data;
-		else
-			throw Error('Statistics service endpoint is not provided');
-	}
-
     static getNodeInfo = async (publicKey) => {
     	let node = {};
 

--- a/src/infrastructure/TransactionService.js
+++ b/src/infrastructure/TransactionService.js
@@ -227,7 +227,7 @@ class TransactionService {
   		...transactions,
   		data: transactions.data.map(({ deadline, ...transaction }) => ({
   			...transaction,
-			age: helper.convertToUTCDate(blockInfos.find(block => block.height === transaction.transactionInfo.height).timestamp),
+  			age: helper.convertToUTCDate(blockInfos.find(block => block.height === transaction.transactionInfo.height).timestamp),
   			height: transaction.transactionInfo.height,
   			transactionHash: transaction.transactionInfo.hash,
   			transactionType: transaction.type,

--- a/src/infrastructure/http.js
+++ b/src/infrastructure/http.js
@@ -19,6 +19,7 @@
 import * as symbol from 'symbol-sdk';
 import { NamespaceService } from '../infrastructure';
 import globalConfig from '../config/globalConfig';
+import { Configuration, NodeApi } from 'symbol-statistics-service-typescript-fetch-client';
 
 let NODE_URL;
 
@@ -145,5 +146,25 @@ export default class http {
 
   static get transactionPaginationStreamer() {
   	return new symbol.TransactionPaginationStreamer(this.createRepositoryFactory.createTransactionRepository());
+  }
+
+  static statisticServiceRestClient() {
+	  try {
+  		const statisticsServiceUrl = globalConfig.endpoints.statisticsService;
+
+  		if (statisticsServiceUrl && statisticsServiceUrl.length) {
+  			return new NodeApi(
+  				new Configuration({
+  					fetchApi: fetch,
+  					basePath: statisticsServiceUrl
+  				})
+  			);
+  		}
+  		else
+  			throw Error('Statistics service endpoint is not provided');
+	  }
+  	catch (error) {
+		  console.error(error);
+	  }
   }
 }


### PR DESCRIPTION
## Add
- statistics-service fetch client package 1.1.3-alpha (will update once release)
- `statisticServiceRestClient` method

## Remove
- Remove `getApiNodeStatus` method, display data from statistics service.
- Remove `getNodeChainInfo` method, display data from statistics service.
- Remove all `/node/peers` endpoint, single source of truth.

## Fix
- wrong `lastStatusCheck` data format.
- CSV export index